### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Security Essentials MVC Project Template
+
+###Created by John Staveley - Last major update 04/09/2016
+
+##Introduction
+This Mvc solution was adapted from the standard MVC4 template in VS 2015, MVC5, .net 4.6.1. Following is how using this solution protects you against the Open Web Application Security Project (OWASP) Top 10 security threats in the world today.
+
+##Security Enhancements
+* SQL Injection: It uses Entity Framework ORM
+* Weak account management: 
+	+ Uses claims based auth
+	+ Uses the strong hash PBKDF2 with an adaptable number of iterations with the experimental Argon2 hashing routine available, new hashing algorithms can be added as better ones are identified or existing ones have weaknesses identified
+	+ Enforces a strong password - Bans weak passwords, enforces minimum password strength, allows special characters, bans too many repeated characters
+	+ Has a water tight account management process
+	+ Prevents anti-enumeration through well designed messages
+	+ Logs account activity which can be checked by the user to see if there is any illicit activity
+	+ Emails on key account events and gives anti-phishing advice
+	+ Verifies email by sending an email to the specified address
+	+ Re-verifies email when requesting a change of email
+	+ Prevents brute force of logon
+	+ Prevents brute force of registration or password reset through anti-throttling and CAPTCHA
+	+ Encryption of security question data using the RijndaelManaged AES 512 encryption algorithm
+	+ Increasing wait time on logon failure rather than account lock out
+	+ Unit tests for password hashing and authorization attributes
+* XSS: Incorporation of the WPL AntiXSS library to encode all output
+* Insecure direct object references: In user edit page it checks the user is entitled to be there
+* Security misconfiguration: Doesn't turn on anything you don't really need
+* Sensitive data exposure: 
+	+ Auto-complete off on registration page
+	+ Enforces TLS of all data in production through use of web.configs
+	+ Ensures website can only ever be requested over TLS using HSTS header
+	+ Turns off verbose errors and trace in production
+	+ Removes unnecessary headers which indicate .net framework version
+	+ Removes server information disclosure headers from responses
+* Missing Function Level Access Control: Sensitive functions decorated with Authorize and Role attributes. Unit tests to ensure admin functions require the admin role
+* CSRF: Ensures anti-forgery token is used on all Post/Put/Ajax operations by checking through use of a base controller
+* Using components with known vulnerabilities: .Net framework is the latest version and all NuGet packages kept updated
+* Unvalidated redirects and forwards: Covered by RedirectToLocal in MVC4
+
+Other threats it protects against and features:
+
+* Clickjacking: Disallow site appearing in frame by applying header and disallowing site from being opened in an iFrame
+* Form overposting: Example given of how to avoid this
+* Acceptance tests for key functionality
+
+***Note:** Runs on SQL Express and IIS Express, requires mail server and recaptcha (optional) set up. See readme.txt in project for more information*

--- a/SecurityEssentials/App_Start/Startup.Auth.cs
+++ b/SecurityEssentials/App_Start/Startup.Auth.cs
@@ -17,9 +17,7 @@ namespace SecurityEssentials.App_Start
 				AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
 				LoginPath = new PathString("/Account/Logon"),
 				CookieName = "SecureAuth",
-#if !DEBUG
-                CookieSecure = CookieSecureOption.Always,
-#endif
+				CookieSecure = CookieSecureOption.SameAsRequest,
 				CookieHttpOnly = true,
 				Provider = new CookieAuthenticationProvider
 				{

--- a/SecurityEssentials/App_Start/Startup.Auth.cs
+++ b/SecurityEssentials/App_Start/Startup.Auth.cs
@@ -19,6 +19,7 @@ namespace SecurityEssentials.App_Start
 #if !DEBUG
                 CookieSecure = CookieSecureOption.Always,
 #endif
+				CookieHttpOnly = true,
 				Provider = new CookieAuthenticationProvider
 				{
 					OnApplyRedirect = ctx =>

--- a/SecurityEssentials/App_Start/Startup.Auth.cs
+++ b/SecurityEssentials/App_Start/Startup.Auth.cs
@@ -9,7 +9,7 @@ namespace SecurityEssentials.App_Start
 	public static partial class Startup
 	{
 		// For more information on configuring authentication, please visit http://go.microsoft.com/fwlink/?LinkId=301864
-		public static void ConfigureAuthorisation(IAppBuilder app)
+		public static void ConfigureAuthentication(IAppBuilder app)
 		{
 			// Enable the application to use a cookie to store information for the signed in user
 			app.UseCookieAuthentication(new CookieAuthenticationOptions

--- a/SecurityEssentials/App_Start/Startup.Auth.cs
+++ b/SecurityEssentials/App_Start/Startup.Auth.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNet.Identity;
+﻿using System;
+using Microsoft.AspNet.Identity;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
@@ -29,7 +30,9 @@ namespace SecurityEssentials.App_Start
 							ctx.Response.Redirect(ctx.RedirectUri);
 						}
 					}
-				}
+				},
+				ExpireTimeSpan = TimeSpan.FromMinutes(60),
+				SlidingExpiration = false
 			});
 			//// Use a cookie to temporarily store information about a user logging in with a third party login provider
 			//app.UseExternalSignInCookie(DefaultAuthenticationTypes.ExternalCookie);

--- a/SecurityEssentials/App_Start/Startup.cs
+++ b/SecurityEssentials/App_Start/Startup.cs
@@ -8,7 +8,7 @@ namespace SecurityEssentials.App_Start
     {
         public static void Configuration(IAppBuilder app)
         {
-            ConfigureAuthorisation(app);
+            ConfigureAuthentication(app);
         }
     }
 }

--- a/SecurityEssentials/Global.asax.cs
+++ b/SecurityEssentials/Global.asax.cs
@@ -15,13 +15,6 @@ namespace SecurityEssentials
 	public class MvcApplication : System.Web.HttpApplication
 	{
 
-		protected void Application_PreSendRequestHeaders()
-		{
-            // SECURE: Remove server information disclosure
-			Response.Headers.Remove("X-AspNet-Version");
-			Response.Headers.Remove("X-AspNetMvc-Version");
-		}
-
 		protected void Application_Start()
 		{
 			AreaRegistration.RegisterAllAreas();
@@ -33,6 +26,10 @@ namespace SecurityEssentials
 			AntiForgeryConfig.UniqueClaimTypeIdentifier = ClaimTypes.Name;
 			//SECURE: Remove automatic XFrame option header so we can add it in filters to entire site
 			System.Web.Helpers.AntiForgeryConfig.SuppressXFrameOptionsHeader = true;
+
+			// SECURE: Remove server information disclosure
+			MvcHandler.DisableMvcResponseHeader = true;
+
 			using (var context = new SEContext())
 			{
 				context.Database.Initialize(true);

--- a/SecurityEssentials/Web.config
+++ b/SecurityEssentials/Web.config
@@ -50,10 +50,6 @@
     <!-- SECURE: Don't disclose version header in each IIS response, encode ALL output including CSS, JavaScript etc, reduce max request length as mitigation against DOS -->
     <httpRuntime targetFramework="4.5" enableVersionHeader="false" encoderType="Microsoft.Security.Application.AntiXssEncoder, AntiXssLibrary" maxRequestLength="4096" />
     <customErrors mode="Off" />
-    <authentication mode="Forms">
-      <!-- SECURE: Reduce timeout time and remove sliding expiration to reduce chance of CSRF/XSS attack -->
-      <forms loginUrl="~/Account/Logon" timeout="60" slidingExpiration="false" />
-    </authentication>
     <pages>
       <namespaces>
         <add namespace="System.Web.Helpers" />

--- a/SecurityEssentials/Web.config
+++ b/SecurityEssentials/Web.config
@@ -49,8 +49,6 @@
     <trace enabled="true" />
     <!-- SECURE: Don't disclose version header in each IIS response, encode ALL output including CSS, JavaScript etc, reduce max request length as mitigation against DOS -->
     <httpRuntime targetFramework="4.5" enableVersionHeader="false" encoderType="Microsoft.Security.Application.AntiXssEncoder, AntiXssLibrary" maxRequestLength="4096" />
-    <!-- SECURE: Any custom cookies used by the application aren't accessible on the client (Depending on your uses, you may wish to switch this off) -->
-    <httpCookies httpOnlyCookies="true" />
     <customErrors mode="Off" />
     <authentication mode="Forms">
       <!-- SECURE: Reduce timeout time and remove sliding expiration to reduce chance of CSRF/XSS attack -->


### PR DESCRIPTION
There's a few changes here, mainly around moving things around to the way that things are setup in the default templates.

Making ALL cookies httpOnly seems a little excessive, and could be annoying to the developer as it's hidden.  As long as the Authentication cookies are hidden, you get enough security for 99% of scenarios.

Not sure that the Forms registration in the web.config was actually taking affect?  

As you're forcing production to use HTTPS, it's simpler to just have "SameAsRequest" instead of forcing HTTPS.  This handles situations where there is SSL termination in play, without compromising your security model (I'll add a separate one that will include support for Secure cookies behind SSL Termination).
